### PR TITLE
Scripts based archives support

### DIFF
--- a/cslauncher/LauncherLib/LauncherConfig.cs
+++ b/cslauncher/LauncherLib/LauncherConfig.cs
@@ -28,6 +28,9 @@ namespace CSLauncher.LauncherLib
         [DataMember(Name = "timeStamp")]
         public string TimeStamp;
 
+        [DataMember(Name = "type")]
+        public string Type;
+
         public LauncherConfig()
         {
             SetDefaults();
@@ -43,6 +46,7 @@ namespace CSLauncher.LauncherLib
         {
             NoWait = false;
             EnvVariables = new EnvVariable[] { };
+            Type = "exe";
         }
     }
 

--- a/cslauncher/LauncherLib/LauncherConfig.cs
+++ b/cslauncher/LauncherLib/LauncherConfig.cs
@@ -27,6 +27,23 @@ namespace CSLauncher.LauncherLib
 
         [DataMember(Name = "timeStamp")]
         public string TimeStamp;
+
+        public LauncherConfig()
+        {
+            SetDefaults();
+        }
+
+        [OnDeserializing]
+        private void OnDeserializing(StreamingContext context)
+        {
+            SetDefaults();
+        }
+
+        private void SetDefaults()
+        {
+            NoWait = false;
+            EnvVariables = new EnvVariable[] { };
+        }
     }
 
     public class AppInfoSerializer
@@ -49,4 +66,4 @@ namespace CSLauncher.LauncherLib
         }
     }
 }
-    
+

--- a/cslauncher/example_scripts.json
+++ b/cslauncher/example_scripts.json
@@ -1,0 +1,27 @@
+{
+    "binPath": "f:\\apps",
+    "installPath": "f:\\apps\\packages",
+    "launcherPath": "Launcher.exe",
+    "launcherLibPath": "LauncherLib.dll",
+    "toolsets": [
+        {
+            "name": "hello",
+            "url": "file://C:/DevTools/sources/hello-1.0.0.zip",
+            "tools": [
+                {
+                    "launcherConfig": {
+                        "exePath": "hello.sh",
+                        "type": "bash",
+                        "envVariables": [
+                            {
+                                "key": "FOO",
+                                "value": "BAR"
+                            }
+                        ]
+                    },
+                    "aliases": ["hello"]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Added support for archives containing scripts.
It also adds optional `envVariable` and `noWait` fields in the `launcherConfig`.

This is more a POC since it would be better to have the script launcher to be a configurable template.
